### PR TITLE
fix: Retain metadata in Docker image version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
           images: ghcr.io/${{ github.event.repository.full_name }}
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha


### PR DESCRIPTION
This ensures metadata is not stripped from the version as reported in docker/metadata-action#384